### PR TITLE
Apply strict rules to combineobject.ts

### DIFF
--- a/combineobject.ts
+++ b/combineobject.ts
@@ -9,7 +9,7 @@ export default function combineObject<T>(sources: {[name: string]: ObservableT<T
     const total = Object.keys(sources).length
     let started = 0
     let completed = 0
-    const values = {}
+    const values: { [name: string]: T } = {}
     for (const name in sources) {
       sources[name].subscribe({
         error,


### PR DESCRIPTION
This applies strict typescript rules:

- Fix "element implicitly has an 'any' type because type '{}' has no index signature."  (TS7017)