### PR TITLE
Add types to tests

### DIFF
--- a/test/combine.ts
+++ b/test/combine.ts
@@ -6,15 +6,15 @@ import {describe, it} from 'mocha'
 describe('combine', () => {
 
   it('calls transform() on the results of each latest next()', done => {
-    const combinations = []
-    const observableA = new Observable(({next, complete}) => {
+    const combinations: string[] = []
+    const observableA = new Observable<string>(({next, complete}) => {
       Promise.resolve()
         .then(() => next('a'))
         .then(() => next('b'))
         .then(() => next('c'))
         .then(() => complete())
     })
-    const observableB = new Observable(({next, complete}) => {
+    const observableB = new Observable<number>(({next, complete}) => {
       Promise.resolve()
         .then(() => next(1))
         .then(() => next(2))

--- a/test/debounce.ts
+++ b/test/debounce.ts
@@ -6,8 +6,8 @@ import {describe, it} from 'mocha'
 describe('debounce', () => {
 
   it('ignores events between every <duration>', done => {
-    const numbers = []
-    debounce(new Observable(({next, complete}) => {
+    const numbers: number[] = []
+    debounce(new Observable<number>(({next, complete}) => {
       next(1)
       setTimeout(() => {
         next(2)
@@ -31,7 +31,7 @@ describe('debounce', () => {
   })
 
   it('always sends back last event if no more come in during <duration>', done => {
-    debounce(new Observable(({next}) => {
+    debounce(new Observable<number>(({next}) => {
       next(1)
       next(2)
       next(3)

--- a/test/filter.ts
+++ b/test/filter.ts
@@ -6,7 +6,7 @@ import {describe, it} from 'mocha'
 describe('filter', () => {
 
   it('only calls next() for every observable.next() that passes predicate', done => {
-    const numbers = []
+    const numbers: number[] = []
     filter(of(5, 10, 15, 20, 25, 30), i => i % 10 === 0).subscribe({
       error: done,
       next(number) { numbers.push(number) },

--- a/test/flatmap.ts
+++ b/test/flatmap.ts
@@ -6,12 +6,12 @@ import {describe, it} from 'mocha'
 describe('flatMap', () => {
 
   it('merges observables coming from transform function', done => {
-    const numbers = []
-    flatMap(new Observable(({next, complete}) => {
+    const numbers: number[] = []
+    flatMap(new Observable<number>(({next, complete}) => {
       next(10)
       next(20)
       complete()
-    }), value => new Observable(({ next, complete }) => {
+    }), value => new Observable<number>(({ next, complete }) => {
       Promise.resolve(value * 2).then(next).then(complete)
     })).subscribe({
       error: done,

--- a/test/fromcallback.ts
+++ b/test/fromcallback.ts
@@ -20,14 +20,14 @@ describe('fromCallback', () => {
   it('calls given callback with args, when subscribed', () => {
     let args = null
     let cbFn = null
-    fromCallback((a, b, c, d: Function) => { args = [a, b, c]; cbFn = d })('a', 'b', 'c').subscribe({})
+    fromCallback((a: string, b : string, c: string, d: Function) => { args = [a, b, c]; cbFn = d })('a', 'b', 'c').subscribe({})
     expect(args).to.deep.equal(['a', 'b', 'c'])
     expect(cbFn).to.be.a('function').with.lengthOf(1)
   })
 
   it('calls next with value from callback', done => {
     const cbValue = {}
-    fromCallback((a, b, cb: Function) => cb(cbValue))('a', 'b').subscribe({
+    fromCallback((a: string, b: string, cb: Function) => cb(cbValue))('a', 'b').subscribe({
       error: done,
       next(value) {
         expect(value).to.equal(cbValue, 'callback value and next value are different')

--- a/test/fromevent.ts
+++ b/test/fromevent.ts
@@ -8,7 +8,7 @@ describe('fromEvent', () => {
     const optionsStub = {}
     const fakeDomNode = {
       removeEventListener() { done(new Error('removeEventListener was called but shoult not have been')) },
-      addEventListener(name, fn, options) {
+      addEventListener(name: string, fn: Function, options: object) {
         expect(name).to.equal('click', 'fromEvent addedEventListener with wrong name')
         expect(fn).to.be.a('function', 'fromEvent addedEventListener passed incorrect callback type')
         expect(options).to.equal(optionsStub, 'fromEvent addedEventListener with wrong options')
@@ -19,13 +19,13 @@ describe('fromEvent', () => {
   })
 
   it('removes event listener on unsubscribe', done => {
-    let nextFn = null
+    let nextFn: Function | null = null
     const optionsStub = {}
     const fakeDomNode = {
-      addEventListener(name, fn) {
+      addEventListener(name: string, fn: Function) {
         nextFn = fn
       },
-      removeEventListener(name, fn, options) {
+      removeEventListener(name: string, fn: Function, options: object) {
         expect(name).to.equal('click', 'fromEvent removedEventListener with wrong name')
         expect(fn).to.equal(nextFn, 'fromEvent removedEventListener passed wrong function')
         expect(options).to.equal(optionsStub, 'fromEvent removedEventListener with wrong options')

--- a/test/frompromise.ts
+++ b/test/frompromise.ts
@@ -5,7 +5,7 @@ import {describe, it} from 'mocha'
 describe('fromPromise', () => {
 
   it('fromPromise success', done => {
-    const numbers = []
+    const numbers: number[] = []
     fromPromise(Promise.resolve(1)).subscribe({
       error: done,
       next(number) { numbers.push(number) },

--- a/test/map.ts
+++ b/test/map.ts
@@ -6,7 +6,7 @@ import {describe, it} from 'mocha'
 describe('map', () => {
 
   it('transforms observable next\'s to new values', done => {
-    const letters = []
+    const letters: string[] = []
     map(of({ letter: 'a' }, { letter: 'b' }, { letter: 'c' }), event => event.letter).subscribe({
       error: done,
       next(letter) { letters.push(letter) },

--- a/test/merge.ts
+++ b/test/merge.ts
@@ -6,7 +6,7 @@ import {describe, it} from 'mocha'
 describe('merge', () => {
 
   it('merges multiple observables', done => {
-    const numbers = []
+    const numbers: number[] = []
     merge(of(1, 2, 3), of(4, 5, 6), of(7, 8, 9)).subscribe({
       error: done,
       next(number) { numbers.push(number) },

--- a/test/observable.ts
+++ b/test/observable.ts
@@ -1,4 +1,6 @@
 import Observable from '../observable'
+import { Subscription } from '../index'
+
 import {expect} from 'chai'
 import {describe, it} from 'mocha'
 
@@ -10,8 +12,8 @@ describe('Observable', () => {
   })
 
   it('can receive events from observable', done => {
-    const letters = []
-    new Observable(({next, complete}) => {
+    const letters: string[] = []
+    new Observable<string>(({next, complete}) => {
       next('a')
       next('b')
       next('c')
@@ -69,8 +71,8 @@ describe('Observable', () => {
   })
 
   it('nothing is fired after complete', done => {
-    const numbers = []
-    new Observable(({next, complete}) => {
+    const numbers: number[] = []
+    new Observable<number>(({next, complete}) => {
       next(1)
       next(2)
       next(3)
@@ -89,8 +91,8 @@ describe('Observable', () => {
   })
 
   it('can unsubscribe to stop receiving events', done => {
-    const numbers = []
-    const {unsubscribe} = new Observable(({next}) => {
+    const numbers: number[] = []
+    const {unsubscribe} = new Observable<number>(({next}) => {
       setTimeout(() => {
         next(1)
         next(2)
@@ -118,8 +120,8 @@ describe('Observable', () => {
   })
 
   it('can observe if the subscription is closed from the return constructor', done => {
-    const numbers = []
-    const subscription = new Observable(({next}) => {
+    const numbers: number[] = []
+    const subscription = new Observable<number>(({next}) => {
       setTimeout(() => {
         next(1)
         next(2)
@@ -150,8 +152,8 @@ describe('Observable', () => {
   })
 
   it('can observe the start of a subscription', done => {
-    const startCalls = []
-    const subscription = new Observable(({next}) => {
+    const startCalls: Subscription[] = []
+    const subscription = new Observable<number>(({next}) => {
       setTimeout(() => {
         next(1)
       })
@@ -167,8 +169,8 @@ describe('Observable', () => {
   })
 
   it('can close the subscription from start', () => {
-    const numbers = []
-    const subscription = new Observable(({next}) => {
+    const numbers: number[] = []
+    const subscription = new Observable<number>(({next}) => {
       next(1)
       next(2)
     }).subscribe({

--- a/test/of.ts
+++ b/test/of.ts
@@ -5,7 +5,7 @@ import {describe, it} from 'mocha'
 describe('of', () => {
 
   it('creates observable of args', done => {
-    const letters = []
+    const letters: string[] = []
     of('a', 'b', 'c').subscribe({
       error: done,
       next(letter) { letters.push(letter) },

--- a/test/skip.ts
+++ b/test/skip.ts
@@ -6,7 +6,7 @@ import {describe, it} from 'mocha'
 describe('skip', () => {
 
   it('skips the first N events', done => {
-    const numbers = []
+    const numbers: number[] = []
     skip(of(1, 2, 3, 4, 5, 6, 7), 3).subscribe({
       error: done,
       next(number) { numbers.push(number) },

--- a/test/skiprepeats.ts
+++ b/test/skiprepeats.ts
@@ -6,7 +6,7 @@ import {describe, it} from 'mocha'
 describe('skipRepeats', () => {
 
   it('only sends through non-repeating events', done => {
-    const numbers = []
+    const numbers: number[] = []
     skipRepeats(of(1, 1, 2, 2, 3, 3, 1, 1)).subscribe({
       error: done,
       next(number) { numbers.push(number) },

--- a/test/startwith.ts
+++ b/test/startwith.ts
@@ -6,7 +6,7 @@ import {describe, it} from 'mocha'
 describe('startWith', () => {
 
   it('pushes value into start of stream', done => {
-    const numbers = []
+    const numbers: number[] = []
     startWith(of(2, 3, 4), 1)
       .subscribe({
         error: done,

--- a/test/switchlatest.ts
+++ b/test/switchlatest.ts
@@ -6,13 +6,13 @@ import {describe, it} from 'mocha'
 describe('switchLatest', () => {
 
   it('cancels any previous in-flight inner observables', done => {
-    const numbers = []
+    const numbers: number[] = []
     switchLatest(
-      new Observable(({next}) => {
+      new Observable<number>(({next}) => {
         setTimeout(next, 100, 1)
         setTimeout(next, 200, 2)
       }),
-      value => new Observable(({next, complete}) => {
+      value => new Observable<number>(({next, complete}) => {
         setTimeout(next, 25, value * 1)
         setTimeout(next, 50, value * 2)
         setTimeout(next, 75, value * 3)
@@ -33,13 +33,13 @@ describe('switchLatest', () => {
   })
 
   it('can be used to sequence promises', done => {
-    const numbers = []
+    const numbers: number[] = []
     switchLatest(
-      new Observable(({next}) => {
+      new Observable<number>(({next}) => {
         next(10)
         next(20)
       }),
-      value => new Observable(({next, complete}) => {
+      value => new Observable<number>(({next, complete}) => {
         Promise.resolve(value * 2).then(next).then(complete)
       })
     ).subscribe({

--- a/test/tc-tests.ts
+++ b/test/tc-tests.ts
@@ -5,7 +5,7 @@ import {describe, it} from 'mocha'
 describe('TC39 tests', () => {
 
   it('TC39 tests (not all will pass)', () =>
-    runTests(Observable).then(status => {
+    runTests(Observable).then((status: any) => {
       if (status.logger.failed > status.logger.passed) {
         throw new Error(`too many tc39 tests failed! (${status.logger.failed + status.logger.errored})`)
       }


### PR DESCRIPTION
This adds types to all the tests that pass strict typing.

Currently the type inference is incorrect for most tests and won't help you not accidentally make mistakes. For example, the default type for a new `Observable` is `{}`. Only after explicitly typing the output arrays (e.g. `let numbers: number[] = []`, you can see that it needs `Observable<number>`. Before that it was all interpreted as `any`.